### PR TITLE
Provide product ids when requesting localized product info

### DIFF
--- a/Sources/SKHelper/Views/SKHelperStoreView.swift
+++ b/Sources/SKHelper/Views/SKHelperStoreView.swift
@@ -103,7 +103,7 @@ public struct SKHelperStoreView<Content: View>: View {
             .padding()
             .onProductsAvailable { _ in hasProducts = store.hasProducts }
             .task {
-                if !hasRequestedProducts, !hasProducts {
+                if !hasRequestedProducts, !hasProducts, store.autoRequestProducts {
                     hasRequestedProducts = true
                     let _ = await store.requestProducts()
                     hasProducts = store.hasProducts

--- a/Sources/SKHelper/Views/SKHelperSubscriptionStoreView.swift
+++ b/Sources/SKHelper/Views/SKHelperSubscriptionStoreView.swift
@@ -129,7 +129,7 @@ public struct SKHelperSubscriptionStoreView<Header: View, Control: View, Details
             .padding()
             .onProductsAvailable { _ in hasProducts = store.hasAutoRenewableSubscriptionProducts }
             .task {
-                if !hasRequestedProducts, !hasProducts {
+                if !hasRequestedProducts, !hasProducts, store.autoRequestProducts {
                     hasRequestedProducts = true
                     let _ = await store.requestProducts()
                     hasProducts = store.hasProducts


### PR DESCRIPTION
Allows developers to control how and when localized product information is requested from the App Store.

This provides greater flexibility, especially when handling product loading manually or in specific scenarios. It also introduces the option to specify product identifiers programmatically when requesting localized product info using the SKHelper.requestProducts(productIds:force:) method.
