### PR TITLE
Enables configurable URLs and custom configs

### DIFF
--- a/Samples/Configuration/Configuration.plist
+++ b/Samples/Configuration/Configuration.plist
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
- The avaiable keys are as follows:
 
-    storeConfiguration
-    productsConfiguration
-    subscriptionsConfiguration
-    subscriptionGroupConfiguration
-    requestRefundUrl
-    contactUsUrl
+Note that these values override the indicated default values used by SKHelper.
+If a key is missing a default value will be used.
 
 -->
 <plist version="1.0">

--- a/Sources/SKHelper/Core/SKHelper.swift
+++ b/Sources/SKHelper/Core/SKHelper.swift
@@ -117,7 +117,10 @@ public class SKHelper: Observable {
         self.autoRequestProducts = autoRequestProducts
         
         if useCachedEntitlements { SKHelperLog.event(.configurationCacheEntitlementsUsed) }
-        if customConfiguration != nil { SKHelperLog.event(.configurationCustomUsed) }
+        if customConfiguration != nil {
+            SKHelperLog.event(.configurationCustomUsed)
+            SKHelperConfiguration.customConfigFile = customConfiguration
+        }
         
         if autoRequestProducts {
             Task { await requestProducts() }
@@ -765,8 +768,6 @@ public class SKHelper: Observable {
         products.forEach { $0.hasEntitlement = false }
         UserDefaults.standard.set([ProductId](), forKey: SKHelperConstants.PurchasedProductsKey)
     }
-    
-    // MARK: - Internal methods
     
     /// Completes a purchase workflow.
     ///

--- a/Sources/SKHelper/Core/SKHelperConstants.swift
+++ b/Sources/SKHelper/Core/SKHelperConstants.swift
@@ -16,6 +16,8 @@ public enum SKHelperConstantKey: String {
     case subscriptionGroupConfiguration = "subscriptionGroupConfiguration"
     case requestRefundUrl               = "requestRefundUrl"
     case contactUsUrl                   = "contactUsUrl"
+    case termsOfServiceUrl              = "termsOfServiceUrl"
+    case privacyPolicyUrl               = "privacyPolicyUrl"
 }
 
 /// Constants used in support of App Store operations.
@@ -38,17 +40,26 @@ public struct SKHelperConstants: Sendable {
     /// The name of the optional section of the Products.plist file that contains a subscription group
     public static let SubscriptionGroupConfiguration = "Group"
     
-    /// A URL which users on macOS can use to request a refund for an IAP.
+    /// A URL which users on macOS can use to request a refund for an IAP. If empty the link is not displayed.
+    /// Default value is "https://reportaproblem.apple.com/".
     public static let RequestRefundUrl = "https://reportaproblem.apple.com/"
     
-    // A URL which can be used to contact the app's developers.
+    /// A URL which can be used to contact the app's developers. If empty the link is not displayed.
     public static let ContactUsUrl = "https://reportaproblem.apple.com/"
+    
+    /// A URL that links to your terms of service. Displayed in the list of products. If empty the link is not displayed.
+    /// Default value is "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/".
+    public static let TermsOfServiceUrl = "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/"
+    
+    /// A URL that links to your privacy policy. Displayed in the list of products. If empty the link is not displayed.
+    /// Default value is an empty string.
+    public static let PrivacyPolicyUrl = "https://reportaproblem.apple.com/"
     
     /// Get the value of a constant by using a key.
     /// - Parameter key: The key of the required value.
     /// - Returns: Returns the value of a constant by using a key, or nil if the value cannot be found.
     ///
-    public static func value(for key: SKHelperConstantKey) -> String? {
+    public static func value(for key: SKHelperConstantKey) -> String {
         switch key {
             case .storeConfiguration:               return SKHelperConstants.StoreConfiguration
             case .purchasedProductsKey:             return SKHelperConstants.PurchasedProductsKey
@@ -57,6 +68,8 @@ public struct SKHelperConstants: Sendable {
             case .subscriptionGroupConfiguration:   return SKHelperConstants.SubscriptionGroupConfiguration
             case .requestRefundUrl:                 return SKHelperConstants.RequestRefundUrl
             case .contactUsUrl:                     return SKHelperConstants.ContactUsUrl
+            case .termsOfServiceUrl:                return SKHelperConstants.TermsOfServiceUrl
+            case .privacyPolicyUrl:                 return SKHelperConstants.PrivacyPolicyUrl
         }
     }
 }

--- a/Sources/SKHelper/Views/SKHelperSubscriptionStoreView.swift
+++ b/Sources/SKHelper/Views/SKHelperSubscriptionStoreView.swift
@@ -67,6 +67,12 @@ public struct SKHelperSubscriptionStoreView<Header: View, Control: View, Details
     /// Used to check multiple times for product availability.
     private let refreshProducts = Timer.publish(every: 1, on: .main, in: .common)
     
+    /// URL used for the app's privacy policy.
+    private var privacyPolicyURL: String = ""
+    
+    /// URL used for the app's terms of service.
+    private var termsOfServiceURL: String = ""
+    
     /// Creates a `SKHelperSubscriptionStoreView`.
     /// - Parameters:
     ///   - subscriptionGroupName: The group name from which subscriptions will be displayed. If nil then all subscriptions in all groups will be displayed.
@@ -83,7 +89,9 @@ public struct SKHelperSubscriptionStoreView<Header: View, Control: View, Details
             self.subscriptionHeader = subscriptionHeader
             self.subscriptionControl = subscriptionControl
             self.subscriptionDetails = subscriptionDetails
-        }
+            self.privacyPolicyURL = SKHelperConfiguration.configurationValue(for: .privacyPolicyUrl)
+            self.termsOfServiceURL = SKHelperConfiguration.configurationValue(for: .termsOfServiceUrl)
+    }
     
     /// Creates the body of the view.
     public var body: some View {
@@ -103,8 +111,8 @@ public struct SKHelperSubscriptionStoreView<Header: View, Control: View, Details
                 #endif
                 .storeButton(.visible, for: .restorePurchases, .policies)
                 .storeButton(.hidden, for: .cancellation)  // Hides the close "X" at the top-right of the view
-                .subscriptionStorePolicyDestination(url: URL(string: "https://russell-archer.github.io/Writerly/privacy/")!, for: .privacyPolicy)
-                .subscriptionStorePolicyDestination(url: URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/")!, for: .termsOfService)
+                .subscriptionStorePolicyDestination(url: URL(string: privacyPolicyURL)!, for: .privacyPolicy)
+                .subscriptionStorePolicyDestination(url: URL(string: termsOfServiceURL)!, for: .termsOfService)
                 .subscriptionStoreControlIcon { subscription, info in
                     if let subscriptionControl { subscriptionControl(subscription.id).SKHelperOnTapGesture(perform: tapAction(subscription: subscription)) }
                     else { defaultSubscriptionControl(productId: subscription.id).SKHelperOnTapGesture(perform: tapAction(subscription: subscription)) }
@@ -202,6 +210,8 @@ extension SKHelperSubscriptionStoreView {
             self.subscriptionHeader = nil
             self.subscriptionControl = nil
             self.subscriptionDetails = subscriptionDetails
+            self.privacyPolicyURL = SKHelperConfiguration.configurationValue(for: .privacyPolicyUrl)
+            self.termsOfServiceURL = SKHelperConfiguration.configurationValue(for: .termsOfServiceUrl)
         }
     
     /// Creates a `SKHelperSubscriptionStoreView`.
@@ -214,6 +224,8 @@ extension SKHelperSubscriptionStoreView {
             self.subscriptionHeader = subscriptionHeader
             self.subscriptionControl = nil
             self.subscriptionDetails = subscriptionDetails
+            self.privacyPolicyURL = SKHelperConfiguration.configurationValue(for: .privacyPolicyUrl)
+            self.termsOfServiceURL = SKHelperConfiguration.configurationValue(for: .termsOfServiceUrl)
         }
 }
 


### PR DESCRIPTION
Allows URLs for privacy policy, terms of service, contact, and refunds to be configured via a plist file rather than being hardcoded.

Adds support for specifying a custom configuration plist file name. This allows for easier customization of the app's behavior without modifying the core code.

Values defined in SKHelperConstants are now overridable via the config plist.
